### PR TITLE
Charging sidekicks do not auto-fire in Tyrian 2000

### DIFF
--- a/src/mainint.c
+++ b/src/mainint.c
@@ -4599,7 +4599,8 @@ redo:
 								}
 								else  // has infinite ammo
 								{
-									if (button[0] || button[1 + i])
+									// Tyrian 2000: weapons with charge stages do not auto-fire
+									if ((button[0] && !this_option->pwr) || button[1 + i])
 									{
 										b = player_shot_create(this_option->wport, shot_i, this_player->sidekick[i].x, this_player->sidekick[i].y, *mouseX_, *mouseY_, this_option->wpnum + this_player->sidekick[i].charge, playerNum_);
 


### PR DESCRIPTION
This was a minor change that I just completely missed.